### PR TITLE
Add missing phone number at restaurant.

### DIFF
--- a/mwzeval/data/database/restaurant_db.json
+++ b/mwzeval/data/database/restaurant_db.json
@@ -619,6 +619,7 @@
             0.118397
         ],
         "name": "ugly duckling",
+        "phone": "01223358281",
         "postcode": "cb21tw",
         "pricerange": "expensive",
         "type": "restaurant"
@@ -762,6 +763,7 @@
             0.145075
         ],
         "name": "meze bar",
+        "phone": "01223410519",
         "postcode": "cb13nf",
         "pricerange": "expensive",
         "type": "restaurant"

--- a/mwzeval/data/database/restaurant_db.json
+++ b/mwzeval/data/database/restaurant_db.json
@@ -1470,6 +1470,7 @@
         ],
         "name": "the slug and lettuce",
         "postcode": "cb23ju",
+        "phone": "01223306051",
         "pricerange": "expensive",
         "type": "restaurant"
     },


### PR DESCRIPTION
I just added the missing phone number.

I refer to https://cambridge.cylex-uk.co.uk/ sites to get phone information.